### PR TITLE
Basic wrapper for google diff-match-patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.vscode
+/venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
+# Env
 /.vscode
 /venv
+
+# Python stuff
+*.pyc
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
-
 FROM        python:3.7-alpine
 
-RUN         mkdir /app
-ADD         requirements.txt /app
+ADD         requirements.txt app.py gdiff.py /app
 RUN         pip install -r /app/requirements.txt
-ADD         app.py /app
-ADD         gdiff.py /app
 
 ENTRYPOINT  ["python", "/app/app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+
+FROM        python:3.7-alpine
+
+RUN         mkdir /app
+ADD         requirements.txt /app
+RUN         pip install -r /app/requirements.txt
+ADD         app.py /app
+ADD         gdiff.py /app
+
+ENTRYPOINT  ["python", "/app/app.py"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ $ omg exec diff t1:"thisisatext" t2:"thisisNOTatext"
 
 ### Storyscript 
 
-> TODO
+```coffeescript
+diff diff t1: "thisisatext" t2: "thisisNOTatext"
+diff diff_raw t1: "thisisatext" t2: "thisisNOTatext"
+```
+
 
 The following show and example output for `GET /diff/?t1=This&t2=boo`
 

--- a/README.md
+++ b/README.md
@@ -12,34 +12,15 @@ $ omg validate
 $ omg exec diff t1:"thisisatext" t2:"thisisNOTatext"
 ```
 
-### StoryScript 
+### Storyscript 
 
 > TODO
-
-### Mnual Build and Run 
-
-```bash
-# Setup 
-$ virtualenv venv --python=python3.6
-$ source venv/bin/activate 
-$ pip install -r requirements.text
-
-# To run tests
-$ python -m unittest 
-
-# To run dev server locally 
-$ python app.py
-
-# To run via Docker 
-$ docker build -t diff . 
-$ docker run diff
-```
 
 The following show and example output for `GET /diff/?t1=This&t2=boo`
 
 #### Example of parsed output via `/parse/`:
 
-```
+```diff
 {
     "diff": "@@ -1,4 +1,3 @@\n-This\n+boo\n",
     "type": "parsed"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
 # diff
-An OMG service to diff text content
+An OMG service to diff text content. Uses google's [diff-match-patch](https://github.com/google/diff-match-patch).
+
+# How to Run
+
+### OMG-CLI
+
+```bash 
+$ npm install -g omg
+
+$ omg validate 
+$ omg exec diff t1:"thisisatext" t2:"thisisNOTatext"
+```
+
+### StoryScript 
+
+> TODO
+
+### Mnual Build and Run 
+
+```bash
+# Setup 
+$ virtualenv venv --python=python3.6
+$ source venv/bin/activate 
+$ pip install -r requirements.text
+
+# To run tests
+$ python -m unittest 
+
+# To run dev server locally 
+$ python app.py
+
+# To run via Docker 
+$ docker build -t diff . 
+$ docker run diff
+```
+
+The following show and example output for `GET /diff/?t1=This&t2=boo`
+
+#### Example of parsed output via `/parse/`:
+
+```
+{
+    "diff": "@@ -1,4 +1,3 @@\n-This\n+boo\n",
+    "type": "parsed"
+}
+```
+
+#### Example of raw output via `/parse/raw/`:
+
+```
+{
+    "diff": [
+        [
+            -1,
+            "This"
+        ],
+        [
+            1,
+            "boo"
+        ]
+    ],
+    "type": "raw"
+}
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,30 @@
+
+from flask import Flask, request, jsonify
+
+from gdiff import GDiff 
+app = Flask(__name__)
+gdiff = GDiff()
+
+@app.route("/diff/raw/", methods=['POST'])
+def diff_raw():
+  content = request.json
+  t1 = content['t1']
+  t2 = content['t2']
+  return jsonify({
+    'diff': gdiff.diff(t1, t2),
+    'type': 'raw'
+  })
+
+@app.route("/diff/", methods=['POST'])
+def diff():
+  content = request.json
+  t1 = content['t1']
+  t2 = content['t2']
+  diff = gdiff.diff(t1, t2)
+  print(diff.split('\n'))
+  return "ok"
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)
+

--- a/app.py
+++ b/app.py
@@ -4,13 +4,8 @@ from flask import Flask, request, jsonify
 
 from gdiff import GDiff 
 
-# TODO: add Dockerfile 
-# TODO: add microservice.yml
-# TODO: add basic unit test
-
 app = Flask(__name__)
 gdiff = GDiff()
-
 
 def validate_diff(fn):
   @wraps(fn)
@@ -58,4 +53,4 @@ def diff():
 
 
 if __name__ == "__main__":
-  app.run(debug=True, port=5000, host='0.0.0.0')
+  app.run(port=5000, host='0.0.0.0')

--- a/app.py
+++ b/app.py
@@ -8,6 +8,10 @@ app = Flask(__name__)
 gdiff = GDiff()
 
 def validate_diff(fn):
+  '''
+  validator function for all endpoints.
+  Currently it adds an unofficial support for GET requests too, which is not dicumented.
+  '''
   @wraps(fn)
   def wrapper(*args, **kwargs):
     if request.method == 'POST':
@@ -46,4 +50,4 @@ def diff():
 
 
 if __name__ == "__main__":
-  app.run(port=5000, host='0.0.0.0')
+  app.run(port=8000, host='0.0.0.0')

--- a/app.py
+++ b/app.py
@@ -1,28 +1,54 @@
 
+from functools import wraps
 from flask import Flask, request, jsonify
 
 from gdiff import GDiff 
+
 app = Flask(__name__)
 gdiff = GDiff()
 
-@app.route("/diff/raw/", methods=['POST'])
+def validate_diff(fn):
+  @wraps(fn)
+  def wrapper(*args, **kwargs):
+    if request.method == 'POST':
+      if not 't1' in request.json or not 't2' in request.json:
+        return jsonify({'error': 't1 and t2 must be present as data.'}), 400
+      else:
+        request.diff_data = request.json
+    elif request.method == 'GET':
+      if not 't1' in request.args or not 't2' in request.args:
+        jsonify({'error': 't1 and t2 must be present as data.'}), 400
+      else:
+        request.diff_data = {}
+        request.diff_data['t1'] = request.args.get('t1')
+        request.diff_data['t2'] = request.args.get('t2')
+    
+    return fn(*args, **kwargs)
+
+  return wrapper
+
+@app.route("/diff/", methods=['POST', 'GET'])
+@validate_diff
 def diff_raw():
-  content = request.json
+  content = request.diff_data
+  t1 = content['t1']
+  t2 = content['t2']
+  return jsonify({
+    'diff': gdiff.dmp.diff_main(t1, t2),
+    'type': 'raw'
+  }), 200
+  
+
+@app.route("/diff/raw/", methods=['POST', 'GET'])
+@validate_diff
+def diff():
+  content = request.diff_data
   t1 = content['t1']
   t2 = content['t2']
   return jsonify({
     'diff': gdiff.diff(t1, t2),
     'type': 'raw'
-  })
-
-@app.route("/diff/", methods=['POST'])
-def diff():
-  content = request.json
-  t1 = content['t1']
-  t2 = content['t2']
-  diff = gdiff.diff(t1, t2)
-  print(diff.split('\n'))
-  return "ok"
+  }), 200
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 from functools import wraps
 from flask import Flask, request, jsonify
 
-from gdiff import GDiff 
+from gdiff import GDiff
 
 app = Flask(__name__)
 gdiff = GDiff()
@@ -11,45 +11,38 @@ def validate_diff(fn):
   @wraps(fn)
   def wrapper(*args, **kwargs):
     if request.method == 'POST':
-      if not 't1' in request.json or not 't2' in request.json:
+      if 't1' not in request.json or 't2' not in request.json:
         return jsonify({'error': 't1 and t2 must be present as data.'}), 400
       else:
         request.diff_data = request.json
     elif request.method == 'GET':
-      if not 't1' in request.args or not 't2' in request.args:
-        jsonify({'error': 't1 and t2 must be present as data.'}), 400
+      if 't1' not in request.args or 't2' not in request.args:
+        return jsonify({'error': 't1 and t2 must be present as data.'}), 400
       else:
         request.diff_data = {}
         request.diff_data['t1'] = request.args.get('t1')
         request.diff_data['t2'] = request.args.get('t2')
-    
     return fn(*args, **kwargs)
 
   return wrapper
 
 
-@app.route("/diff/", methods=['POST', 'GET'])
+@app.route("/diff/raw/", methods=['POST', 'GET'])
 @validate_diff
 def diff_raw():
-  content = request.diff_dat
+  content = request.diff_data
   t1 = content['t1']
   t2 = content['t2']
-  return jsonify({
-    'diff': gdiff.dmp.diff_main(t1, t2),
-    'type': 'raw'
-  }), 200
+  return jsonify({'diff': gdiff.dmp.diff_main(t1, t2), 'type': 'raw'}), 200
 
 
-@app.route("/diff/raw/", methods=['POST', 'GET'])
+@app.route("/diff/", methods=['POST', 'GET'])
 @validate_diff
 def diff():
   content = request.diff_data
   t1 = content['t1']
   t2 = content['t2']
-  return jsonify({
-    'diff': gdiff.diff(t1, t2),
-    'type': 'parsed'
-  }), 200
+  return jsonify({'diff': gdiff.diff(t1, t2), 'type': 'parsed'}), 200
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -4,8 +4,13 @@ from flask import Flask, request, jsonify
 
 from gdiff import GDiff 
 
+# TODO: add Dockerfile 
+# TODO: add microservice.yml
+# TODO: add basic unit test
+
 app = Flask(__name__)
 gdiff = GDiff()
+
 
 def validate_diff(fn):
   @wraps(fn)
@@ -27,17 +32,18 @@ def validate_diff(fn):
 
   return wrapper
 
+
 @app.route("/diff/", methods=['POST', 'GET'])
 @validate_diff
 def diff_raw():
-  content = request.diff_data
+  content = request.diff_dat
   t1 = content['t1']
   t2 = content['t2']
   return jsonify({
     'diff': gdiff.dmp.diff_main(t1, t2),
     'type': 'raw'
   }), 200
-  
+
 
 @app.route("/diff/raw/", methods=['POST', 'GET'])
 @validate_diff
@@ -47,10 +53,9 @@ def diff():
   t2 = content['t2']
   return jsonify({
     'diff': gdiff.diff(t1, t2),
-    'type': 'raw'
+    'type': 'parsed'
   }), 200
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000)
-
+  app.run(debug=True, port=5000, host='0.0.0.0')

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 
 from functools import wraps
 from flask import Flask, request, jsonify
@@ -7,47 +8,40 @@ from gdiff import GDiff
 app = Flask(__name__)
 gdiff = GDiff()
 
-def validate_diff(fn):
-  '''
-  validator function for all endpoints.
-  Currently it adds an unofficial support for GET requests too, which is not dicumented.
-  '''
-  @wraps(fn)
-  def wrapper(*args, **kwargs):
-    if request.method == 'POST':
-      if 't1' not in request.json or 't2' not in request.json:
-        return jsonify({'error': 't1 and t2 must be present as data.'}), 400
-      else:
-        request.diff_data = request.json
-    elif request.method == 'GET':
-      if 't1' not in request.args or 't2' not in request.args:
-        return jsonify({'error': 't1 and t2 must be present as data.'}), 400
-      else:
-        request.diff_data = {}
-        request.diff_data['t1'] = request.args.get('t1')
-        request.diff_data['t2'] = request.args.get('t2')
-    return fn(*args, **kwargs)
 
-  return wrapper
+def validate_diff(fn):
+    '''
+    Validator function for all endpoints.
+    '''
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        if request.method == 'POST':
+            if 't1' not in request.json or 't2' not in request.json:
+                return jsonify(
+                    {'error': 't1 and t2 must be present as data.'}), 400
+            else:
+                request.diff_data = request.json
+        return fn(*args, **kwargs)
+    return wrapper
 
 
 @app.route("/diff/raw/", methods=['POST', 'GET'])
 @validate_diff
 def diff_raw():
-  content = request.diff_data
-  t1 = content['t1']
-  t2 = content['t2']
-  return jsonify({'diff': gdiff.dmp.diff_main(t1, t2), 'type': 'raw'}), 200
+    content = request.diff_data
+    t1 = content['t1']
+    t2 = content['t2']
+    return jsonify({'diff': gdiff.dmp.diff_main(t1, t2), 'type': 'raw'}), 200
 
 
 @app.route("/diff/", methods=['POST', 'GET'])
 @validate_diff
 def diff():
-  content = request.diff_data
-  t1 = content['t1']
-  t2 = content['t2']
-  return jsonify({'diff': gdiff.diff(t1, t2), 'type': 'parsed'}), 200
+    content = request.diff_data
+    t1 = content['t1']
+    t2 = content['t2']
+    return jsonify({'diff': gdiff.diff(t1, t2), 'type': 'parsed'}), 200
 
 
 if __name__ == "__main__":
-  app.run(port=8000, host='0.0.0.0')
+    app.run(port=8000, host='0.0.0.0')

--- a/gdiff.py
+++ b/gdiff.py
@@ -4,10 +4,10 @@ class GDiff:
   def __init__(self):
     self.dmp = diff_match_patch()
   
-  def _patch(self, t1, t2):
+  def _patch(self, t1, t2) -> object:
     return self.dmp.patch_make(t1, t2)
 
-  def diff(self, t1, t2):
+  def diff(self, t1, t2) -> str:
     patch = self._patch(t1, t2)
     diff = self.dmp.patch_toText(patch)    
     return diff

--- a/gdiff.py
+++ b/gdiff.py
@@ -1,0 +1,13 @@
+from diff_match_patch import diff_match_patch
+
+class GDiff:
+  def __init__(self):
+    self.dmp = diff_match_patch()
+  
+  def _patch(self, t1, t2):
+    return self.dmp.patch_make(t1, t2)
+
+  def diff(self, t1, t2):
+    patch = self._patch(t1, t2)
+    diff = self.dmp.patch_toText(patch)    
+    return diff

--- a/gdiff.py
+++ b/gdiff.py
@@ -1,7 +1,8 @@
 from diff_match_patch import diff_match_patch
 
+
 class GDiff:
-  def __init__(self):
+  def __init__(self) -> None:
     self.dmp = diff_match_patch()
   
   def _patch(self, t1, t2) -> object:

--- a/gdiff.py
+++ b/gdiff.py
@@ -4,11 +4,11 @@ from diff_match_patch import diff_match_patch
 class GDiff:
   def __init__(self) -> None:
     self.dmp = diff_match_patch()
-  
+
   def _patch(self, t1, t2) -> object:
     return self.dmp.patch_make(t1, t2)
 
   def diff(self, t1, t2) -> str:
     patch = self._patch(t1, t2)
-    diff = self.dmp.patch_toText(patch)    
+    diff = self.dmp.patch_toText(patch)
     return diff

--- a/gdiff.py
+++ b/gdiff.py
@@ -2,13 +2,13 @@ from diff_match_patch import diff_match_patch
 
 
 class GDiff:
-  def __init__(self) -> None:
-    self.dmp = diff_match_patch()
+    def __init__(self) -> None:
+        self.dmp = diff_match_patch()
 
-  def _patch(self, t1, t2) -> object:
-    return self.dmp.patch_make(t1, t2)
+    def _patch(self, t1, t2) -> object:
+        return self.dmp.patch_make(t1, t2)
 
-  def diff(self, t1, t2) -> str:
-    patch = self._patch(t1, t2)
-    diff = self.dmp.patch_toText(patch)
-    return diff
+    def diff(self, t1, t2) -> str:
+        patch = self._patch(t1, t2)
+        diff = self.dmp.patch_toText(patch)
+        return diff

--- a/microservice.yml
+++ b/microservice.yml
@@ -1,4 +1,3 @@
-
 omg: 1
 lifecycle:
   startup:
@@ -26,7 +25,7 @@ actions:
         type:
           type: string
         diff:
-          type: object 
+          type: string 
 
   diff_raw:
     http:

--- a/microservice.yml
+++ b/microservice.yml
@@ -1,0 +1,41 @@
+
+omg: 1
+lifecycle:
+  startup:
+    command: ["python", "/app/app.py"]
+actions:
+  diff:
+    http:
+      path: /diff/
+      port: 8000
+      method: post
+    arguments:
+      t1: 
+        type: string
+        required: true
+        in: requestBody
+      t2:
+        type: string
+        required: true
+        in: requestBody
+    output: 
+      contentType: application/json
+      type: object
+
+  diff_raw:
+    http:
+      path: /diff/raw/
+      port: 8000
+      method: post
+    arguments:
+      t1: 
+        type: string
+        required: true
+        in: requestBody
+      t2:
+        type: string
+        required: true
+        in: requestBody
+    output: 
+      contentType: application/json
+      type: object

--- a/microservice.yml
+++ b/microservice.yml
@@ -9,6 +9,7 @@ actions:
       path: /diff/
       port: 8000
       method: post
+      contentType: application/json
     arguments:
       t1: 
         type: string
@@ -21,12 +22,18 @@ actions:
     output: 
       contentType: application/json
       type: object
+      properties:
+        type:
+          type: string
+        diff:
+          type: object 
 
   diff_raw:
     http:
       path: /diff/raw/
       port: 8000
       method: post
+      contentType: application/json
     arguments:
       t1: 
         type: string
@@ -39,3 +46,8 @@ actions:
     output: 
       contentType: application/json
       type: object
+      properties:
+        type:
+          type: string
+        diff:
+          type: object

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+diff-match-patch==20181111
+Flask==1.0.2

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -1,0 +1,32 @@
+import unittest
+import json
+
+from app import app
+app.testing = True
+
+PAYLOAD = {'t1': 'This is a Text', 't2': 'this is NOT a Text'}
+PAYLOAD_NULL = {'t1': 'This is a Text', 't3': 'this is NOT a Text'}
+
+
+class TestDiff(unittest.TestCase):
+  def test_basic(self):  
+    with app.test_client() as cl:
+      response = cl.post('/diff/', data=json.dumps(PAYLOAD), content_type='application/json')
+      self.assertEqual(response.status_code, 200)
+
+      response = cl.get('/diff/', query_string=PAYLOAD, content_type='application/json')
+      self.assertEqual(response.status_code, 200)
+
+      response = cl.post('/diff/raw/', data=json.dumps(PAYLOAD), content_type='application/json')
+      self.assertEqual(response.status_code, 200)
+
+      response = cl.get('/diff/raw/', query_string=PAYLOAD, content_type='application/json')
+      self.assertEqual(response.status_code, 200)
+
+  def test_null(self):
+    with app.test_client() as cl:
+      response = cl.post('/diff/', data=json.dumps(PAYLOAD_NULL), content_type='application/json')
+      self.assertEqual(response.status_code, 400)
+
+      response = cl.get('/diff/raw/', query_string=PAYLOAD_NULL, content_type='application/json')
+      self.assertEqual(response.status_code, 400)

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,3 @@
 [pep8]
-  ignore = E226,E302,E41
+  ignore = E226,E302,E41,E111
   max-line-length = 160

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,0 @@
-[pep8]
-  ignore = E226,E302,E41,E111
-  max-line-length = 160

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,3 @@
+[pep8]
+  ignore = E226,E302,E41
+  max-line-length = 160


### PR DESCRIPTION
Some notes: 

- `omg exec` currently fails after building the container despite the arguments being provided. 
- The API implicitly supports both GET and POST methods, while GET is documented and used. 